### PR TITLE
Add Mark's new tooltip to deck edit header

### DIFF
--- a/epc-ui.js
+++ b/epc-ui.js
@@ -581,7 +581,7 @@ function buildEpcUI(graphStyle) {
     /*  Bind all buttons to their behavior handlers  */
     function bindButtons() {
         $(window).bind("load", onLoad);
-        $(".menu-help-icon").popup({
+        $(".help-icon").popup({
             position: "top right",
             offset: 6
         });

--- a/epc.css
+++ b/epc.css
@@ -409,10 +409,15 @@ body {
 
 .deck-edit-header,
 .deck-edit-footer {
-    width: 245px;
-    margin: 30px;
+    margin: 30px 15px;
     display: flex;
     justify-content: space-between;
+    align-items: center;
+}
+
+.help-icon {
+    height: 18px;
+    width: 18px;
 }
 
 .deck-edit-header .button,
@@ -554,7 +559,7 @@ body {
     margin: 40px 0px 0px 40px;
 }
 
-.menu-help-icon {
+.output-tab-help-icon {
     float: right;
     margin: 40px 40px 0px 0px;
 }

--- a/index.html
+++ b/index.html
@@ -347,6 +347,12 @@
                             data-content="Link copied to clipboard">
                         <img src="link.svg">
                     </button>
+
+                    <img class="help-icon"
+                        src="menu-help-icon.png" float="left">
+                    <div class="ui popup menu-help">
+                        IMPORT or EXPORT your deck here. Use  <img src="link.svg" width="19" border="1"style="border-radius: 4px; background-color: #27252D; border: solid .75px #FFFFFF; padding: 4px;"> to SHARE your deck with a unique URL.
+                    </div>
                 </div>
 
                 <div id="deck-edit" class="deck-edit">
@@ -409,7 +415,7 @@
                         <img id="influence-graph-menu-title"
                             class="menu-title"
                             src="influence-graph-menu.png">
-                        <img class="menu-help-icon"
+                        <img class="output-tab-help-icon help-icon"
                             src="menu-help-icon.png">
                         <div class="ui popup menu-help">
                             Charts the odds (0-100%) of meeting
@@ -421,7 +427,7 @@
                         <img id="power-odds-table-menu-title"
                             class="menu-title"
                             src="power-odds-table-menu.png">
-                        <img class="menu-help-icon"
+                        <img class="output-tab-help-icon help-icon"
                             src="menu-help-icon.png">
                         <div class="ui popup menu-help">
                             Tabulates the odds (0-100%) of meeting


### PR DESCRIPTION
This adds the new tooltip you were working on 

Notes for positioning since you mentioned you got stuck on it:

* Needed to put inside deck-edit-header element
* Matt used display: flex (aka flexbox) for deck-edit-header so needed to know how to use that. Flexbox is actually great, so it's worth learning https://css-tricks.com/snippets/css/a-guide-to-flexbox/
* Needed to remove css class that was only meant for use on the large tabs above output area (was adding a wonky margin)
